### PR TITLE
Fixed Collection.remove

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -213,8 +212,8 @@ Collection.prototype.remove = function (search, opts, fn) {
   search = this.cast(search);
 
   // query
-  debug('%s remove "%j" with "%j"', this.name, search, update);
-  this.col.update(search, this.opts(opts), promise.fulfill);
+  debug('%s remove "%j"', this.name, search);
+  this.col.remove(search, this.opts(opts), promise.fulfill);
 
   return promise;
 };


### PR DESCRIPTION
It was giving a logging error, and was using the .update method instead of .remove.  This fixes those problems, and .remove works now.
