### PR TITLE
Check for URI

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -25,6 +24,10 @@ module.exports = Manager;
  */
 
 function Manager (uri, opts, fn) {
+  if (!uri) {
+    throw Error('No connection URI provided.');
+  }
+  
   if (!(this instanceof Manager)) {
     return new Manager(uri, opts, fn);
   }


### PR DESCRIPTION
Check for connection URI and throw Error if it doesn't exist.

I was having configuration problems with my app and the connection string I was passing to monk was undefined because of it. I thought having a clearer message for this case (instead of the one resulting from trying to call indexOf on undefined) would be helpful.
