### PR TITLE
 Bugfix for parameter handling in findAndModify

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -243,8 +242,8 @@ Collection.prototype.findAndModify = function (query, update, opts, fn) {
       , update: update
     };
   } else {
-    opts = update;
     fn = opts;
+    opts = update;
   }
 
   if ('string' == typeof query.query || 'function' == typeof query.query.toHexString) {


### PR DESCRIPTION
The fn and opts assignments are in the wrong order. fn is being overwritten by opts new value instead of it's old one.
