### PR TITLE
Fix mongoskin version so install works

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   , "tags": ["mongodb", "mongo", "driver"]
   , "repository": { "type": "git", "url": "git://github.com/LearnBoost/monk.git" }
   , "dependencies": {
-        "mongoskin": "1.3.14"
+        "mongoskin": "0.6.1"
       , "debug": "*"
       , "mpromise": "~0.4.1"
     }


### PR DESCRIPTION
The dependency of mongoskin v0.4.4 was causing a wall of build errors:

``` bash
node-gyp clean
node-gyp configure build
  CXX(target) Release/obj.target/bson/ext/bson.o
In file included from ../ext/bson.cc:35:
../ext/bson.h:52:51: error: unknown type name 'Arguments'; did you mean 'v8::internal::Arguments'?
        static Handle<Value> BSONDeserializeStream(const Arguments &args);
                                                         ^~~~~~~~~
                                                         v8::internal::Arguments

many more lines here
```

It looks like there are some shenanigans going on with mongoskin, so I had to dial in on a version that worked and wasn't the latest version in npm (alpha on a minor release version with reported breaking changes / bugs, old versions seemingly removed).

This fix will make it so monk will install correctly.
