### PR TITLE
Addition of `close()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ users.insert({ name: 'Tobi', bigdata: {} });
 users.find({ name: 'Loki' }, '-bigdata', function () {
   // exclude bigdata field
 });
+
+db.close()
 ```
 
 ## Features
@@ -43,6 +45,12 @@ var db = require('monk')('localhost/mydb')
 
 ```js
 var db = require('monk')('localhost/mydb,192.168.1.1')
+```
+
+### Disconnecting
+
+```js
+db.close()
 ```
 
 ### Collections


### PR DESCRIPTION
Couldn't find any reference to closing a connection in the docs so have added it to both the top example and a section headed "Disconnecting".
