### PR TITLE
Add collection save method

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -340,7 +340,6 @@ Collection.prototype.save = function (data, opts, fn) {
     promise.complete(fn);
   }
 
-
   // cast
   data = this.cast(data);
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -327,6 +327,42 @@ Collection.prototype.insert = function (data, opts, fn) {
   return promise;
 };
 
+Collection.prototype.save = function (data, opts, fn) {
+  if ('function' == typeof opts) {
+    fn = opts;
+    opts = {};
+  }
+
+  opts = this.opts(opts);
+  var promise = new Promise(this, 'save', opts);
+
+  if (fn) {
+    promise.complete(fn);
+  }
+
+
+  // cast
+  data = this.cast(data);
+
+  // run query
+  debug('%s save %j', this.name, data);
+  if (data._id) {
+    this.col.save(data, opts, function (err, doc) {
+      process.nextTick(function () {
+        promise.resolve.call(promise, err, data);
+      });
+    });
+  } else {
+    this.col.insert(data, opts, function (err, docs) {
+      process.nextTick(function () {
+        promise.resolve.call(promise, err, docs ? docs[0] : docs);
+      });
+    });
+  }
+
+  return promise;
+};
+
 /**
  * findOne by ID
  *

--- a/test/collection.test.js
+++ b/test/collection.test.js
@@ -105,6 +105,34 @@ describe('collection', function () {
     });
   });
 
+  describe('saving', function () {
+    it('should insert document', function (done) {
+      users.save({a: 'save'}, function (err, obj) {
+        expect(err).to.be(null);
+        expect(obj._id.toHexString).to.not.be(undefined);
+        done();
+      });
+    });
+
+    it('should update existing document', function (done) {
+      users.insert({a: 'save2'}, function (err, obj) {
+        expect(err).to.be(null);
+        expect(obj.a).to.equal('save2');
+
+        var orig = obj._id;
+
+        obj.a = 'save3';
+
+        users.save(obj, function (err, obj) {
+          expect(err).to.be(null);
+          expect(obj.a).to.equal('save3');
+          expect(orig).to.equal(obj._id);
+          done();
+        });
+      });
+    });
+  });
+
   describe('finding', function () {
     it('should find by id', function (done) {
       users.insert({ c: 'd' }, function (err, doc) {


### PR DESCRIPTION
I'm taking some inspiration from https://github.com/marcello3d/node-mongolian here, in that we don't call the native mongo save and instead choose update or insert based on the presence of an _id field. This is mostly because the value returned by mongo from save (and update for that matter) isn't very useful (we get the number of saved/updated documents back). In this implementation, we return either the inserted document when _id is present, or the document passed to save when it isn't.

Refs: #53 #43