### PR TITLE
Inserting an array returns an array

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -311,6 +311,7 @@ Collection.prototype.insert = function (data, opts, fn) {
   if (fn) {
     promise.complete(fn);
   }
+  var arrayInsert = Array.isArray(data);
 
   // cast
   data = this.cast(data);
@@ -320,7 +321,11 @@ Collection.prototype.insert = function (data, opts, fn) {
   promise.query = data;
   this.col.insert(data, opts, function (err, docs) {
     process.nextTick(function () {
-      promise.resolve.call(promise, err, docs ? docs[0] : docs);
+      var res = docs;
+      if (docs && !arrayInsert) {
+        res = docs[0];
+      }
+      promise.resolve.call(promise, err, res);
     });
   });
 

--- a/test/collection.test.js
+++ b/test/collection.test.js
@@ -103,6 +103,14 @@ describe('collection', function () {
         done();
       });
     });
+
+    it('should return an array if an array was inserted', function (done) {
+      var p = users.insert([{ a: 'b' }, { b: 'a' }], function (err, docs) {
+        expect(docs).to.be.an('array');
+        expect(docs.length).to.be(2);
+        done();
+      });
+    });
   });
 
   describe('finding', function () {


### PR DESCRIPTION
I was a bit confused by this behavior. Mongo allows one to insert multiple document at once via an array, and the array is then returned. However, monk chooses to convert the array to a single object.

I think that if an array was inserted an array should be returned.
