### PR TITLE
upgrade; mongoskin to 1.4.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git://github.com/LearnBoost/monk.git"
   },
   "dependencies": {
-    "mongoskin": "1.4.11",
+    "mongoskin": "1.4.13",
     "debug": "*",
     "mpromise": "0.5.1"
   },


### PR DESCRIPTION
Hi Guillermo,

mongoskin 1.4.11 is bugging out because of the release of mongodb driver 2.0. I bumped mongoskin to 1.4.13 to make sure it uses mongodb ~1.4.