### PR TITLE
Specify mongodb to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "mongoskin": "1.4.13",
+    "mongodb": "~1.4",
     "debug": "*",
     "mpromise": "0.5.1"
   },


### PR DESCRIPTION
To fix for NPM 3.
If not, the following warning is shown and mongodb is not installed.
```
├── UNMET PEER DEPENDENCY mongodb@~1.4
```