### PR TITLE
Exclude tests from coverage results and instrument all files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ lint:
 
 test: lint
 	echo "  $(P) Testing"
-	NODE_ENV=test $(BIN_DIR)/nyc $(BIN_DIR)/ava $(TEST_TARGET)
+	NODE_ENV=test $(BIN_DIR)/nyc --all $(BIN_DIR)/ava $(TEST_TARGET)
 
 test-watch:
 	echo "  $(P) Testing forever"

--- a/package.json
+++ b/package.json
@@ -32,5 +32,10 @@
   "scripts": {
     "test": "make test",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov"
+  },
+  "nyc": {
+    "exclude": [
+      "tests/**"
+    ]
   }
 }


### PR DESCRIPTION
Since every `lib/` file is currently required by the tests, the latter change does not make much of a difference ATM, but it will later on. :)

The alternative would be to rename the `tests/` folder to `test/` since that's excluded by default in `nyc`, but since it's configurable this is a little less friction.