### PR TITLE
2.1

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,4 @@
 {
   "extends": ["standard"],
-  "ignorePath": ".gitignore",
-  "rules": {
-    "no-proto": 0
-  }
+  "ignorePath": ".gitignore"
 }

--- a/History.md
+++ b/History.md
@@ -1,4 +1,10 @@
-2.0.0 / 2016-06-15
+2.1.0 / 2016-06-23
+==================
+ - add aggregate method (#56)
+ - add dropIndex and dropIndexes methods (#113)
+ - use `util.inherits` instead of `__proto__`
+
+2.0.0 / 2016-06-23
 ==================
 complete rewrite of monk:
  - return real promises (#104)

--- a/History.md
+++ b/History.md
@@ -15,7 +15,6 @@ complete rewrite of monk:
  - Support $ne, $in, $nin for id casting
  - Make the sort option behave like fields
 
-
 1.0.1 / 2015-03-25
 ==================
 

--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
  - add aggregate method (#56)
  - add dropIndex and dropIndexes methods (#113)
  - use `util.inherits` instead of `__proto__`
+ - Add `castIds` option to disable the automatic id casting (#1, #72)
 
 2.0.0 / 2016-06-23
 ==================

--- a/README.md
+++ b/README.md
@@ -193,6 +193,12 @@ closing the `then` handler will be called.
 users.remove({ a: 'b' })
 ```
 
+### Aggregate
+
+```js
+users.aggregate(stages, {})
+```
+
 ### Global options
 
 ```js

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ users.findOne({ name: 'test' }).then((doc) => {})
 
 ```js
 users.findAndModify({ query: {}, update: {} })
-users.findAndModify({ _id: '' }, { $set: {} })
+users.findAndModify({ _id: '' }, { $set: {} }, { new: true })
 ```
 
 #### Streaming

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -4,6 +4,7 @@
 
 var util = require('./util')
 var debug = require('debug')('monk:queries')
+var inherits = require('util').inherits
 var EventEmitter = require('events').EventEmitter
 
 /**
@@ -52,7 +53,7 @@ function Collection (manager, name) {
  * Inherits from EventEmitter.
  */
 
-Collection.prototype.__proto__ = EventEmitter.prototype
+inherits(Collection, EventEmitter)
 
 /**
  * Casts to objectid

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -35,6 +35,7 @@ function Collection (manager, name) {
   this.index = this.ensureIndex = this.ensureIndex.bind(this)
   this.dropIndex = this.dropIndex.bind(this)
   this.indexes = this.indexes.bind(this)
+  this.dropIndexes = this.dropIndexes.bind(this)
   this.update = this.update.bind(this)
   this.updateById = this.updateById.bind(this)
   this.remove = this.remove.bind(this)
@@ -141,6 +142,23 @@ Collection.prototype.dropIndex = function (fields, opts, fn) {
   debug('%s dropIndex %j (%j)', this.name, fields, opts)
   return new Promise(function (resolve, reject) {
     this.col.dropIndex(fields, opts, util.callback(resolve, reject, fn))
+  }.bind(this))
+}
+
+/**
+ * Drop all indexes.
+ *
+ * @param {Object|Function} optional, options or callback
+ * @param {Function} optional, callback
+ * @return {Promise}
+ * @api public
+ */
+
+Collection.prototype.dropIndexes = function (fn) {
+  // query
+  debug('%s dropIndexes', this.name)
+  return new Promise(function (resolve, reject) {
+    this.col.dropIndexes(util.callback(resolve, reject, fn))
   }.bind(this))
 }
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -46,6 +46,7 @@ function Collection (manager, name) {
   this.distinct = this.distinct.bind(this)
   this.count = this.count.bind(this)
   this.findOne = this.findOne.bind(this)
+  this.aggregate = this.aggregate.bind(this)
   this.drop = this.drop.bind(this)
   this.cast = this.cast.bind(this)
 }
@@ -535,6 +536,29 @@ Collection.prototype.drop = function (fn) {
       }
       util.callback(resolve, reject, fn)(err, res)
     })
+  }.bind(this))
+}
+
+/**
+ * aggregate
+ *
+ * @param {Array} aggregation stages
+ * @param {Object|Function} optional, options or callback
+ * @param {Function} optional, callback
+ * @return {Promise}
+ */
+
+Collection.prototype.aggregate = function (stages, opts, fn) {
+  if (typeof opts === 'function') {
+    fn = opts
+    opts = {}
+  }
+
+  opts = this.opts(opts)
+  // query
+  debug('%s aggregate %j', this.name, stages)
+  return new Promise(function (resolve, reject) {
+    this.col.aggregate(stages, opts, util.callback(resolve, reject, fn))
   }.bind(this))
 }
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -110,7 +110,7 @@ Collection.prototype.ensureIndex = function (fields, opts, fn) {
   }
 
   fields = util.fields(fields)
-  opts = opts || {}
+  opts = this.opts(opts)
 
   // query
   debug('%s ensureIndex %j (%j)', this.name, fields, opts)
@@ -136,7 +136,7 @@ Collection.prototype.dropIndex = function (fields, opts, fn) {
   }
 
   fields = util.fields(fields)
-  opts = opts || {}
+  opts = this.opts(opts)
 
   // query
   debug('%s dropIndex %j (%j)', this.name, fields, opts)
@@ -302,7 +302,7 @@ Collection.prototype.findAndModify = function (query, update, opts, fn) {
     opts = {}
   }
 
-  opts = opts || {}
+  opts = this.opts(opts)
 
   // `new` defaults to `true` for upserts
   if (opts.new == null && opts.upsert) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -33,6 +33,7 @@ function Collection (manager, name) {
   this.oid = this.id = this.id.bind(this)
   this.opts = this.opts.bind(this)
   this.index = this.ensureIndex = this.ensureIndex.bind(this)
+  this.dropIndex = this.dropIndex.bind(this)
   this.indexes = this.indexes.bind(this)
   this.update = this.update.bind(this)
   this.updateById = this.updateById.bind(this)
@@ -113,6 +114,32 @@ Collection.prototype.ensureIndex = function (fields, opts, fn) {
   debug('%s ensureIndex %j (%j)', this.name, fields, opts)
   return new Promise(function (resolve, reject) {
     this.col.ensureIndex(fields, opts, util.callback(resolve, reject, fn))
+  }.bind(this))
+}
+
+/**
+ * Drop indexes.
+ *
+ * @param {Object|String|Array} fields
+ * @param {Object|Function} optional, options or callback
+ * @param {Function} optional, callback
+ * @return {Promise}
+ * @api public
+ */
+
+Collection.prototype.dropIndex = function (fields, opts, fn) {
+  if (typeof opts === 'function') {
+    fn = opts
+    opts = {}
+  }
+
+  fields = util.fields(fields)
+  opts = opts || {}
+
+  // query
+  debug('%s dropIndex %j (%j)', this.name, fields, opts)
+  return new Promise(function (resolve, reject) {
+    this.col.dropIndex(fields, opts, util.callback(resolve, reject, fn))
   }.bind(this))
 }
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -201,8 +201,10 @@ Collection.prototype.update = function (search, update, opts, fn) {
   opts = this.opts(opts)
 
   // cast
-  search = this.cast(search)
-  update = this.cast(update)
+  if (opts.castIds !== false) {
+    search = this.cast(search)
+    update = this.cast(update)
+  }
 
   // query
   debug('%s update %j with %j', this.name, search, update)
@@ -246,7 +248,9 @@ Collection.prototype.remove = function (search, opts, fn) {
   opts = this.opts(opts)
 
   // cast
-  search = this.cast(search)
+  if (opts.castIds !== false) {
+    search = this.cast(search)
+  }
 
   // query
   debug('%s remove %j with %j', this.name, search, opts)
@@ -310,8 +314,10 @@ Collection.prototype.findAndModify = function (query, update, opts, fn) {
   }
 
   // cast
-  query.query = this.cast(query.query)
-  query.update = this.cast(query.update)
+  if (opts.castIds !== false) {
+    query.query = this.cast(query.query)
+    query.update = this.cast(query.update)
+  }
 
   // query
   debug('%s findAndModify %j with %j', this.name, query.query, query.update)
@@ -348,7 +354,9 @@ Collection.prototype.insert = function (data, opts, fn) {
   var arrayInsert = Array.isArray(data)
 
   // cast
-  data = this.cast(data)
+  if (opts.castIds !== false) {
+    data = this.cast(data)
+  }
 
   // query
   debug('%s insert %j', this.name, data)
@@ -393,11 +401,13 @@ Collection.prototype.find = function (query, opts, fn) {
     opts = {}
   }
 
-  // cast
-  query = this.cast(query)
-
   // opts
   opts = this.opts(opts)
+
+  // cast
+  if (opts.castIds !== false) {
+    query = this.cast(query)
+  }
 
   // query
   debug('%s find %j', this.name, query)
@@ -527,7 +537,9 @@ Collection.prototype.findOne = function (search, opts, fn) {
   opts = this.opts(opts)
 
   // cast
-  search = this.cast(search)
+  if (opts.castIds !== false) {
+    search = this.cast(search)
+  }
 
   // query
   debug('%s findOne %j', this.name, search)

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -415,13 +415,7 @@ Collection.prototype.find = function (query, opts, fn) {
   var didClose = false
   var promise = new Promise(function (resolve, reject) {
     Promise.resolve(this.col.find(query, opts)).then(function (cursor) {
-      if (opts.stream == null) {
-        if (promise.eachListener) {
-          stream()
-        } else {
-          cursor.toArray(util.callback(resolve, reject, fn))
-        }
-      } else if (opts.stream) {
+      if (opts.stream || promise.eachListener) {
         stream()
       } else {
         cursor.toArray(util.callback(resolve, reject, fn))

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -7,6 +7,7 @@ var debug = require('debug')('monk:manager')
 var Collection = require('./collection')
 var ObjectId = mongoskin.ObjectID
 var EventEmitter = require('events').EventEmitter
+var inherits = require('util').inherits
 
 /**
  * Module exports.
@@ -79,7 +80,7 @@ function Manager (uri, opts, fn) {
  * Inherits from EventEmitter
  */
 
-Manager.prototype.__proto__ = EventEmitter.prototype
+inherits(Manager, EventEmitter)
 
 /**
  * Open callback.

--- a/lib/util.js
+++ b/lib/util.js
@@ -31,11 +31,12 @@ exports.callback = function (resolve, reject, fn, middleware) {
  * Parses all the possible ways of expressing fields.
  *
  * @param {String|Object|Array} fields
+ * @param {number} number when -
  * @return {Object} fields in object format
  * @api public
  */
 
-exports.fields = function (obj) {
+exports.fields = function (obj, numberWhenMinus) {
   if (!Array.isArray(obj) && typeof obj === 'object') {
     return obj
   }
@@ -45,7 +46,7 @@ exports.fields = function (obj) {
 
   for (var i = 0, l = obj.length; i < l; i++) {
     if (obj[i][0] === '-') {
-      fields[obj[i].substr(1)] = 0
+      fields[obj[i].substr(1)] = numberWhenMinus
     } else {
       fields[obj[i]] = 1
     }
@@ -67,7 +68,7 @@ exports.options = function (opts) {
     return { fields: exports.fields(opts) }
   }
   opts = opts || {}
-  opts.fields = exports.fields(opts.fields)
-  opts.sort = exports.fields(opts.sort)
+  opts.fields = exports.fields(opts.fields, 0)
+  opts.sort = exports.fields(opts.sort, -1)
   return opts
 }

--- a/tests/collection.js
+++ b/tests/collection.js
@@ -233,6 +233,14 @@ test('update > should update with an objectid (string)', (t) => {
   })
 })
 
+test('update > should fail properly', (t) => {
+  return users.insert([{ woot: 'cb', d: 'e' }, { woot: 'ca' }]).then(([_, doc]) => {
+    return users.update(doc._id, { $set: { woot: 'cb' } })
+  }).catch(() => {
+    t.pass()
+  })
+})
+
 test('remove > should remove a document', (t) => {
   return users.insert({ woot: 'u', name: 'Tobi' }).then((doc) => {
     return users.remove({ name: 'Tobi' })
@@ -299,6 +307,26 @@ test('findAndModify > should upsert', (t) => {
       t.is(found._id.toString(), doc._id.toString())
       t.is(found.find, rand)
     })
+  })
+})
+
+test('aggregate > should fail properly', (t) => {
+  return users.aggregate().catch(() => {
+    t.pass()
+  })
+})
+
+test('aggregate > should work in normal case', (t) => {
+  return users.aggregate([{$group: {_id: null, maxWoot: { $max: '$woot' }}}]).then((res) => {
+    t.true(Array.isArray(res))
+    t.is(res.length, 1)
+  })
+})
+
+test('aggregate > should work with option', (t) => {
+  return users.aggregate([{$group: {_id: null, maxWoot: { $max: '$woot' }}}], { allowDiskUse: true }).then((res) => {
+    t.true(Array.isArray(res))
+    t.is(res.length, 1)
   })
 })
 

--- a/tests/collection.js
+++ b/tests/collection.js
@@ -232,6 +232,16 @@ test('find > should allow stream cursor destroy', (t) => {
   })
 })
 
+test.cb('find > stream callback', (t) => {
+  const query = { stream: 3 }
+  users.insert([{ stream: 3 }, { stream: 3 }, { stream: 3 }, { stream: 3 }]).then(() => {
+    return users.find(query, t.end)
+      .each((doc) => {
+        t.not(doc.a, null)
+      })
+  })
+})
+
 test('count > should count', (t) => {
   return users.count({ a: 'counting' }).then((count) => {
     t.is(count, 0)
@@ -392,6 +402,11 @@ test.cb('findAndModify > callback', (t) => {
     , { upsert: true }, t.end)
 })
 
+test.cb('findAndModify > callback', (t) => {
+  const rand = 'now-' + Date.now()
+  users.findAndModify({ query: {find: rand}, update: { find: rand } }, t.end)
+})
+
 test('aggregate > should fail properly', (t) => {
   return users.aggregate().catch(() => {
     t.pass()
@@ -437,4 +452,12 @@ test('should allow defaults', (t) => {
   }).then(({n}) => {
     t.true(n && n <= 1)
   })
+})
+
+test('drop > should not throw when dropping an empty db', (t) => {
+  db.get('dropDB-' + Date.now()).drop().then(() => t.pass())
+})
+
+test.cb('drop > callback', (t) => {
+  db.get('dropDB2-' + Date.now()).drop(t.end)
 })

--- a/tests/collection.js
+++ b/tests/collection.js
@@ -335,7 +335,7 @@ test('aggregate > should work in normal case', (t) => {
 })
 
 test('aggregate > should work with option', (t) => {
-  return users.aggregate([{$group: {_id: null, maxWoot: { $max: '$woot' }}}], { allowDiskUse: true }).then((res) => {
+  return users.aggregate([{$group: {_id: null, maxWoot: { $max: '$woot' }}}], { explain: true }).then((res) => {
     t.true(Array.isArray(res))
     t.is(res.length, 1)
   })

--- a/tests/collection.js
+++ b/tests/collection.js
@@ -88,10 +88,13 @@ test.cb('dropIndex > callback', (t) => {
 
 test('dropIndexes > should drop all indexes', (t) => {
   const col = db.get('indexDrop-' + Date.now())
-  return col.index({ up2: 1, down: -1 }).then(col.indexes).then((indexes) => {
+  return col.index({ up2: 1, down: -1 })
+  .then(col.indexes)
+  .then((indexes) => {
     t.not(indexes['up2_1_down_-1'], undefined)
   }).then(() => col.dropIndexes())
-  .then(col.indexes).then((indexes) => {
+  .then(col.indexes)
+  .then((indexes) => {
     t.is(indexes['up2_1_down_'], undefined)
   })
 })
@@ -455,7 +458,7 @@ test('should allow defaults', (t) => {
 })
 
 test('drop > should not throw when dropping an empty db', (t) => {
-  db.get('dropDB-' + Date.now()).drop().then(() => t.pass())
+  return db.get('dropDB-' + Date.now()).drop().then(() => t.pass()).catch(() => t.fail())
 })
 
 test.cb('drop > callback', (t) => {

--- a/tests/collection.js
+++ b/tests/collection.js
@@ -39,6 +39,42 @@ test('index > should accept options', (t) => {
   })
 })
 
+test('dropIndex > should accept a field string', (t) => {
+  return users.index('name2.first').then(users.indexes).then((indexes) => {
+    t.not(indexes['name2.first_1'], undefined)
+  }).then(() => users.dropIndex('name2.first'))
+  .then(users.indexes).then((indexes) => {
+    t.is(indexes['name2.first_1'], undefined)
+  })
+})
+
+test('dropIndex > should accept space-delimited compound indexes', (t) => {
+  return users.index('name2 last').then(users.indexes).then((indexes) => {
+    t.not(indexes.name2_1_last_1, undefined)
+  }).then(() => users.dropIndex('name2 last'))
+  .then(users.indexes).then((indexes) => {
+    t.is(indexes.name2_1_last_1, undefined)
+  })
+})
+
+test('dropIndex > should accept array compound indexes', (t) => {
+  return users.index(['nombre2', 'apellido']).then(users.indexes).then((indexes) => {
+    t.not(indexes.nombre2_1_apellido_1, undefined)
+  }).then(() => users.dropIndex(['nombre2', 'apellido']))
+  .then(users.indexes).then((indexes) => {
+    t.is(indexes.nombre2_1_apellido_1, undefined)
+  })
+})
+
+test('dropIndex > should accept object compound indexes', (t) => {
+  return users.index({ up2: 1, down: -1 }).then(users.indexes).then((indexes) => {
+    t.not(indexes['up2_1_down_-1'], undefined)
+  }).then(() => users.dropIndex({ up2: 1, down: -1 }))
+  .then(users.indexes).then((indexes) => {
+    t.is(indexes['up2_1_down_'], undefined)
+  })
+})
+
 test('insert > should force callback in next tick', (t) => {
   return users.insert({ woot: 'a' }).then(() => t.pass())
 })

--- a/tests/collection.js
+++ b/tests/collection.js
@@ -75,6 +75,15 @@ test('dropIndex > should accept object compound indexes', (t) => {
   })
 })
 
+test('dropIndexes > should drop all indexes', (t) => {
+  return users.index({ up2: 1, down: -1 }).then(users.indexes).then((indexes) => {
+    t.not(indexes['up2_1_down_-1'], undefined)
+  }).then(() => users.dropIndexes())
+  .then(users.indexes).then((indexes) => {
+    t.is(indexes['up2_1_down_'], undefined)
+  })
+})
+
 test('insert > should force callback in next tick', (t) => {
   return users.insert({ woot: 'a' }).then(() => t.pass())
 })

--- a/tests/collection.js
+++ b/tests/collection.js
@@ -132,7 +132,7 @@ test('find > should only provide selected fields', (t) => {
 
 test('find > should sort', (t) => {
   return users.insert([{ sort: true, a: 1, b: 2 }, { sort: true, a: 1, b: 1 }]).then(() => {
-    return users.find({ sort: true }, { sort: 'a b' })
+    return users.find({ sort: true }, { sort: '-a b' })
   }).then((docs) => {
     t.is(docs[0].b, 1)
     t.is(docs[1].b, 2)

--- a/tests/collection.js
+++ b/tests/collection.js
@@ -9,55 +9,55 @@ test.after(() => {
   return users.drop()
 })
 
-test('should accept a field string', (t) => {
+test('index > should accept a field string', (t) => {
   return users.index('name.first').then(users.indexes).then((indexes) => {
     t.not(indexes['name.first_1'], undefined)
   })
 })
 
-test('should accept space-delimited compound indexes', (t) => {
+test('index > should accept space-delimited compound indexes', (t) => {
   return users.index('name last').then(users.indexes).then((indexes) => {
     t.not(indexes.name_1_last_1, undefined)
   })
 })
 
-test('should accept array compound indexes', (t) => {
+test('index > should accept array compound indexes', (t) => {
   return users.index(['nombre', 'apellido']).then(users.indexes).then((indexes) => {
     t.not(indexes.nombre_1_apellido_1, undefined)
   })
 })
 
-test('should accept object compound indexes', (t) => {
+test('index > should accept object compound indexes', (t) => {
   return users.index({ up: 1, down: -1 }).then(users.indexes).then((indexes) => {
     t.not(indexes['up_1_down_-1'], undefined)
   })
 })
 
-test('should accept options', (t) => {
+test('index > should accept options', (t) => {
   return users.index({ woot: 1 }, { unique: true }).then(users.indexes).then((indexes) => {
     t.not(indexes.woot_1, undefined)
   })
 })
 
-test('should force callback in next tick', (t) => {
+test('insert > should force callback in next tick', (t) => {
   return users.insert({ woot: 'a' }).then(() => t.pass())
 })
 
-test('should give you an object with the _id', (t) => {
+test('insert > should give you an object with the _id', (t) => {
   return users.insert({ woot: 'b' }).then((obj) => {
     t.is(typeof obj._id, 'object')
     t.not(obj._id.toHexString, undefined)
   })
 })
 
-test('should return an array if an array was inserted', (t) => {
+test('insert > should return an array if an array was inserted', (t) => {
   return users.insert([{ woot: 'c' }, { woot: 'd' }]).then((docs) => {
     t.true(Array.isArray(docs))
     t.is(docs.length, 2)
   })
 })
 
-test('should find by id', (t) => {
+test('findById > should find by id', (t) => {
   return users.insert({ woot: 'e' }).then((doc) => {
     return users.findById(doc._id).then((doc) => {
       t.is(doc.woot, 'e')
@@ -65,7 +65,7 @@ test('should find by id', (t) => {
   })
 })
 
-test('should only provide selected fields', (t) => {
+test('find > should only provide selected fields', (t) => {
   return users.insert({ woot: 'f', a: 'b', c: 'd', e: 'f' }).then((doc) => {
     return users.findOne(doc._id, 'a e')
   }).then((doc) => {
@@ -75,7 +75,7 @@ test('should only provide selected fields', (t) => {
   })
 })
 
-test('should sort', (t) => {
+test('find > should sort', (t) => {
   return users.insert([{ woot: 'g', sort: true, a: 1, b: 2 }, { woot: 'h', sort: true, a: 1, b: 1 }]).then(() => {
     return users.find({ sort: true }, { sort: 'a b' })
   }).then((docs) => {
@@ -84,7 +84,7 @@ test('should sort', (t) => {
   })
 })
 
-test('should work with streaming', (t) => {
+test('find > should work with streaming', (t) => {
   const query = { stream: 1 }
   let found = 0
   return users.insert([{ woot: 'aa', stream: 1 }, { woot: 'ab', stream: 1 }, { woot: 'ac', stream: 1 }, { woot: 'ad', stream: 1 }]).then(() => {
@@ -99,7 +99,7 @@ test('should work with streaming', (t) => {
   })
 })
 
-test('should work with streaming option', (t) => {
+test('find > should work with streaming option', (t) => {
   const query = { stream: 2 }
   let found = 0
   return users.insert([{ woot: 'ae', stream: 2 }, { woot: 'af', stream: 2 }, { woot: 'ag', stream: 2 }, { woot: 'ah', stream: 2 }]).then(() => {
@@ -114,7 +114,7 @@ test('should work with streaming option', (t) => {
   })
 })
 
-test('should allow stream cursor destroy', (t) => {
+test('find > should allow stream cursor destroy', (t) => {
   const query = { cursor: { $exists: true } }
   let found = 0
   return users.insert([{ woot: 'i', cursor: true }, { woot: 'j', cursor: true }, { woot: 'k', cursor: true }, { woot: 'l', cursor: true }]).then(() => {
@@ -138,7 +138,7 @@ test('should allow stream cursor destroy', (t) => {
   })
 })
 
-test('should count', (t) => {
+test('count > should count', (t) => {
   return users.count({ a: 'counting' }).then((count) => {
     t.is(count, 0)
     return users.insert({ woot: 'm', a: 'counting' })
@@ -157,7 +157,7 @@ test('distinct', (t) => {
   })
 })
 
-test('should update', (t) => {
+test('update > should update', (t) => {
   return users.insert({ woot: 'q', d: 'e' }).then((doc) => {
     return users.update({ _id: doc._id }, { $set: { d: 'f' } }).then(() => {
       return users.findById(doc._id)
@@ -167,7 +167,7 @@ test('should update', (t) => {
   })
 })
 
-test('should update by id', (t) => {
+test('updateById > should update by id', (t) => {
   return users.insert({ woot: 'r', d: 'e' }).then((doc) => {
     return users.updateById(doc._id, { $set: { d: 'f' } }).then(() => {
       return users.findById(doc._id)
@@ -177,7 +177,7 @@ test('should update by id', (t) => {
   })
 })
 
-test('should update with an objectid', (t) => {
+test('update > should update with an objectid', (t) => {
   return users.insert({ woot: 's', d: 'e' }).then((doc) => {
     return users.update(doc._id, { $set: { d: 'f' } }).then(() => {
       return users.findById(doc._id)
@@ -187,7 +187,7 @@ test('should update with an objectid', (t) => {
   })
 })
 
-test('should update with an objectid (string)', (t) => {
+test('update > should update with an objectid (string)', (t) => {
   return users.insert({ woot: 't', d: 'e' }).then((doc) => {
     return users.update(doc._id.toString(), { $set: { d: 'f' } }).then(() => {
       return users.findById(doc._id)
@@ -197,7 +197,7 @@ test('should update with an objectid (string)', (t) => {
   })
 })
 
-test('should remove a document', (t) => {
+test('remove > should remove a document', (t) => {
   return users.insert({ woot: 'u', name: 'Tobi' }).then((doc) => {
     return users.remove({ name: 'Tobi' })
   }).then(() => {
@@ -207,7 +207,7 @@ test('should remove a document', (t) => {
   })
 })
 
-test('should remove a document by id', (t) => {
+test('removeById > should remove a document by id', (t) => {
   return users.insert({ woot: 'v', name: 'Mathieu' }).then((doc) => {
     return users.removeById(doc._id)
   }).then(() => {
@@ -217,7 +217,7 @@ test('should remove a document by id', (t) => {
   })
 })
 
-test('should alter an existing document', (t) => {
+test('findAndModify > should alter an existing document', (t) => {
   const rand = 'now-' + Date.now()
   return users.insert({ find: rand, woot: 'w' }).then(() => {
     return users.findAndModify({ find: rand }, { find: 'woot' }, { new: true })
@@ -230,7 +230,7 @@ test('should alter an existing document', (t) => {
   })
 })
 
-test('should accept an id as query param', (t) => {
+test('findAndModify > should accept an id as query param', (t) => {
   return users.insert({ locate: 'me', woot: 'x' }).then((user) => {
     return users.findAndModify(user._id, { $set: { locate: 'you' } }).then(() => {
       return users.findOne(user._id)
@@ -240,7 +240,7 @@ test('should accept an id as query param', (t) => {
   })
 })
 
-test('should accept an id as query param (mongo syntax)', (t) => {
+test('findAndModify > should accept an id as query param (mongo syntax)', (t) => {
   return users.insert({ locate: 'me', woot: 'y' }).then((user) => {
     return users.findAndModify({ query: user._id, update: { $set: { locate: 'you' } } }).then(() => {
       return users.findOne(user._id)
@@ -250,7 +250,7 @@ test('should accept an id as query param (mongo syntax)', (t) => {
   })
 })
 
-test('should upsert', (t) => {
+test('findAndModify > should upsert', (t) => {
   const rand = 'now-' + Date.now()
 
   return users.findAndModify(

--- a/tests/collection.js
+++ b/tests/collection.js
@@ -337,7 +337,7 @@ test('aggregate > should work in normal case', (t) => {
 test('aggregate > should work with option', (t) => {
   return users.aggregate([{$group: {_id: null, maxWoot: { $max: '$woot' }}}], { explain: true }).then((res) => {
     t.true(Array.isArray(res))
-    t.is(res.length, 1)
+    t.is(res.length, 2)
   })
 })
 


### PR DESCRIPTION
 - add aggregate method ( fix #56)
 - add dropIndex and dropIndexes methods (fix #113)
 - use `util.inherits` instead of `__proto__`
 - Add `castIds` option to disable the automatic id casting (fix #1, #72)