### PR TITLE
delete wrong options for ensureIndex

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -322,7 +322,6 @@ Collection.prototype.ensureIndex = function (fields, opts, fn) {
   }
 
   fields = util.fields(fields)
-  opts = this.opts(opts)
 
   // query
   debug('%s ensureIndex %j (%j)', this.name, fields, opts)


### PR DESCRIPTION
MongoDB 3.4 enforces a stricter validation of index specification during createIndexes and db.collection.createIndex() operations. The enforcement does not apply to existing indexes.

https://docs.mongodb.com/manual/release-notes/3.4-compatibility/#stricter-validation-of-index-specifications

fixed errors like: (fields, sort, safe) should not be send)

`
MongoError: The field 'fields' is not valid for an index specification. Specification: { ns: "databasename", key:
{ keyfield: 1 }
, name: "keyfield_1", unique: true, fields: {}, sort: {}, safe: true }
`
