### PR TITLE
Remove mention of options.safe

### DIFF
--- a/docs/manager/README.md
+++ b/docs/manager/README.md
@@ -37,9 +37,12 @@ require('monk')('localhost/mydb,192.168.1.1').then((db) => {
 
 #### Options
 
-You can set options to pass to every queries. By default, monk set
+You can set options to pass to every query. By default, monk doesn't set any options.
+
+Set options like this:
+
 ```js
 db.options = {
-  safe: true
+  poolSize: 7
 }
 ```


### PR DESCRIPTION
With the Release of 4.0.0, the default `safe` option was removed, but in the Docs, it was still mentioned.