### PR TITLE
#216: added db.listCollections

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare module 'monk' {
     ) => void
 
     readonly close: () => Promise<void>
-    readonly listCollections: (query?: Object) => Array<any>
+    readonly listCollections: (query?: Object) => Array<ICollection>
 
     get<T = any>(name: string, options?: Object): ICollection<T>
     create<T = any>(

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,7 @@ declare module 'monk' {
     ) => void
 
     readonly close: () => Promise<void>
+    readonly listCollections: (query?: Object) => Array<any>
 
     get<T = any>(name: string, options?: Object): ICollection<T>
     create<T = any>(

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -243,6 +243,19 @@ Manager.prototype.close = function (force, fn) {
 }
 
 /**
+ * Lists all collections.
+ *
+ * @param {Object} [query] - A query expression to filter the list of collections.
+ * @return {Array} array of all collections
+ */
+
+Manager.prototype.listCollections = function (query) {
+  if(!query) query = undefined
+  return this._db.listCollections(query).toArray()
+}
+
+
+/**
  * Gets a collection.
  *
  * @param {String} name - name of the mongo collection

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -250,8 +250,11 @@ Manager.prototype.close = function (force, fn) {
  */
 
 Manager.prototype.listCollections = function (query) {
+  var self = this
   return this.executeWhenOpened().then(function (db) {
-    return db.listCollections(query).toArray()
+    return db.listCollections(query).toArray().map(
+      x => self.get(x.name)
+    )
   })
 }
 

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -252,9 +252,9 @@ Manager.prototype.close = function (force, fn) {
 Manager.prototype.listCollections = function (query) {
   var self = this
   return this.executeWhenOpened().then(function (db) {
-    return db.listCollections(query).toArray().map(
+    return db.listCollections(query).toArray().then(x => x.map(
       x => self.get(x.name)
-    )
+    ))
   })
 }
 

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -250,8 +250,9 @@ Manager.prototype.close = function (force, fn) {
  */
 
 Manager.prototype.listCollections = function (query) {
-  if (!query) query = undefined
-  return this._db.listCollections(query).toArray()
+  return this.executeWhenOpened().then(function (db) {
+    return db._db.listCollections(query).toArray()
+  })
 }
 
 /**

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -250,10 +250,9 @@ Manager.prototype.close = function (force, fn) {
  */
 
 Manager.prototype.listCollections = function (query) {
-  if(!query) query = undefined
+  if (!query) query = undefined
   return this._db.listCollections(query).toArray()
 }
-
 
 /**
  * Gets a collection.

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -250,8 +250,9 @@ Manager.prototype.close = function (force, fn) {
  */
 
 Manager.prototype.listCollections = function (query) {
+  var self = this
   return this.executeWhenOpened().then(function (db) {
-    return db._db.listCollections(query).toArray()
+    return db.listCollections(query).toArray()
   })
 }
 

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -250,7 +250,6 @@ Manager.prototype.close = function (force, fn) {
  */
 
 Manager.prototype.listCollections = function (query) {
-  var self = this
   return this.executeWhenOpened().then(function (db) {
     return db.listCollections(query).toArray()
   })

--- a/test/monk.js
+++ b/test/monk.js
@@ -128,7 +128,7 @@ test('Manager#get', (t) => {
 })
 
 test('Manager#listCollections', (t) => {
-  t.true(db.listCollections() instanceof Array)
+  return db.listCollections().then(collections => t.true(collections instanceof Array))
 })
 
 test('Manager#col', (t) => {

--- a/test/monk.js
+++ b/test/monk.js
@@ -127,6 +127,10 @@ test('Manager#get', (t) => {
   t.true(db.get('users') instanceof Collection)
 })
 
+test('Manager#listCollections', (t) => {
+  t.true(db.listCollections() instanceof Array)
+})
+
 test('Manager#col', (t) => {
   t.true(db.col('users') instanceof Collection)
 })


### PR DESCRIPTION
Provides a method to access `listCollections` without using `db._db`.
If the Mongo API will change in future releases, the Monk Team/Community just have to care about this method, as the `db._db` property is not meant to be used by Monk users. 

For further details:
closes #216 