### PR TITLE
#282: Srv mongo uri regex allowance

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -84,7 +84,7 @@ function Manager (uri, opts, fn) {
   }
 
   if (typeof uri === 'string') {
-    if (!/^mongodb:\/\//.test(uri)) {
+    if (!/^mongodb(\+srv)?:\/\//.test(uri)) {
       uri = 'mongodb://' + uri
     }
   }

--- a/test/monk.js
+++ b/test/monk.js
@@ -20,6 +20,11 @@ test('Should throw if no uri provided', (t) => {
   }
 })
 
+test('Should handle srv connection string', (t) => {
+  const m = monk('mongodb+srv://user:pw@host');
+  t.true('mongodb+srv://user:pw@host' === m._connectionURI);
+})
+
 test.cb('to a regular server', (t) => {
   t.plan(2)
   monk('127.0.0.1/monk-test', (err, db) => {

--- a/test/monk.js
+++ b/test/monk.js
@@ -22,7 +22,7 @@ test('Should throw if no uri provided', (t) => {
 
 test('Should handle srv connection string', (t) => {
   const m = monk('mongodb+srv://user:pw@host')
-  t.true(m._connectionURI=== 'mongodb+srv://user:pw@host')
+  t.true(m._connectionURI === 'mongodb+srv://user:pw@host')
 })
 
 test.cb('to a regular server', (t) => {

--- a/test/monk.js
+++ b/test/monk.js
@@ -21,8 +21,8 @@ test('Should throw if no uri provided', (t) => {
 })
 
 test('Should handle srv connection string', (t) => {
-  const m = monk('mongodb+srv://user:pw@host');
-  t.true('mongodb+srv://user:pw@host' === m._connectionURI);
+  const m = monk('mongodb+srv://user:pw@host')
+  t.true(m._connectionURI=== 'mongodb+srv://user:pw@host')
 })
 
 test.cb('to a regular server', (t) => {


### PR DESCRIPTION
Allows for srv connection string modifier within the regex test against mongo URI within Manager. Fixes #282