### PR TITLE
Docs: Change debug `monk:queries` to `monk:query`

### DIFF
--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -14,7 +14,7 @@ db.addMiddleware(require('monk-middleware-debug'))
   [debug](http://github.com/visionmedia/debug):
 
   ```bash
-  DEBUG="monk:queries" npm start
+  DEBUG="monk:query" npm start
   ```
 
 * To see all debugging output from monk:


### PR DESCRIPTION
`monk:queries` doesn't seem to work, but `monk:query` does:

<img width="211" alt="Screenshot 2019-12-13 at 09 24 41" src="https://user-images.githubusercontent.com/30257156/70785186-65de9600-1d8a-11ea-9c59-2cb70062e278.png">
