### PR TITLE
feat(collection): uses projection, added on find

### DIFF
--- a/docs/collection/findOne.md
+++ b/docs/collection/findOne.md
@@ -19,17 +19,17 @@ A promise.
 #### Example
 
 ```js
-users.findOne({ name: 'foo' }).then((doc) => {});
+users.findOne({name: 'foo'}).then((doc) => {});
 ```
 
 ```js
-users.findOne({ name: 'foo' }, 'name').then((doc) => {
+users.findOne({name: 'foo'}, 'name').then((doc) => {
   // only the name projection will be selected
 });
-users.findOne({ name: 'foo' }, { projection: { name: 1 } }); // equivalent
+users.findOne({name: 'foo'}, { projection: { name: 1 } }); // equivalent
 
-users.findOne({ name: 'foo' }, '-name').then((doc) => {
+users.findOne({name: 'foo'}, '-name').then((doc) => {
   // all the fields except the name projection will be selected
 });
-users.findOne({ name: 'foo' }, { projection: { name: -1 } }); // equivalent
+users.findOne({name: 'foo'}, { projection: {name: -1} }); // equivalent
 ```

--- a/docs/collection/findOne.md
+++ b/docs/collection/findOne.md
@@ -1,14 +1,14 @@
 # `collection.findOne`
 
-[Mongo documentation <i class="fa fa-external-link" style="position: relative; top: 2px;" />](http://mongodb.github.io/node-mongodb-native/3.2/api/Collection.html#findOne)
+[Mongo documentation <i class="fa fa-external-link" style="position: relative; top: 2px;" />](https://mongodb.github.io/node-mongodb-native/3.2/api/Collection.html#findOne)
 
-Returns one document that satisfies the specified query criteria. If multiple documents satisfy the query, this method returns the first document according to the natural order which reflects the order of documents on the disk. In capped collections, natural order is the same as insertion order. If no document satisfies the query, the method returns null.
+Returns one document that satisfies the specified query criteria on the collection or view. If multiple documents satisfy the query, this method returns the first document according to the natural order which reflects the order of documents on the disk. In capped collections, natural order is the same as insertion order. If no document satisfies the query, the method returns null.
 
 #### Arguments
 
 1. `query` *(String|ObjectId|Object)*
 
-2. [`options`] *(Object|String|Array)*: If the `options` is a string, it will be parsed as the fields to select.
+2. [`options`] *(Object|String|Array)*: If the `options` is a string, it will be parsed as the projections to select.
 
 3. [`callback`] *(function)*
 
@@ -19,16 +19,17 @@ A promise.
 #### Example
 
 ```js
-users.findOne({name: 'foo'}).then((doc) => {})
+users.findOne({ name: "foo" }).then((doc) => {});
 ```
-```js
-users.findOne({name: 'foo'}, 'name').then((doc) => {
-  // only the name field will be selected
-})
-users.findOne({name: 'foo'}, { fields: { name: 1 } }) // equivalent
 
-users.findOne({name: 'foo'}, '-name').then((doc) => {
-  // all the fields except the name field will be selected
-})
-users.findOne({name: 'foo'}, { fields: { name: -1 } }) // equivalent
+```js
+users.findOne({ name: "foo" }, "name").then((doc) => {
+  // only the name projection will be selected
+});
+users.findOne({ name: "foo" }, { projection: { name: 1 } }); // equivalent
+
+users.findOne({ name: "foo" }, "-name").then((doc) => {
+  // all the fields except the name projection will be selected
+});
+users.findOne({ name: "foo" }, { projection: { name: -1 } }); // equivalent
 ```

--- a/docs/collection/findOne.md
+++ b/docs/collection/findOne.md
@@ -19,17 +19,17 @@ A promise.
 #### Example
 
 ```js
-users.findOne({ name: "foo" }).then((doc) => {});
+users.findOne({ name: 'foo' }).then((doc) => {});
 ```
 
 ```js
-users.findOne({ name: "foo" }, "name").then((doc) => {
+users.findOne({ name: 'foo' }, 'name').then((doc) => {
   // only the name projection will be selected
 });
-users.findOne({ name: "foo" }, { projection: { name: 1 } }); // equivalent
+users.findOne({ name: 'foo' }, { projection: { name: 1 } }); // equivalent
 
-users.findOne({ name: "foo" }, "-name").then((doc) => {
+users.findOne({ name: 'foo' }, '-name').then((doc) => {
   // all the fields except the name projection will be selected
 });
-users.findOne({ name: "foo" }, { projection: { name: -1 } }); // equivalent
+users.findOne({ name: 'foo' }, { projection: { name: -1 } }); // equivalent
 ```

--- a/test/collection.js
+++ b/test/collection.js
@@ -173,12 +173,12 @@ test('findOne > should only provide selected fields', (t) => {
   })
 })
 
-test('find > should project only specified fields using fields options', t => {
+test('find > should project only specified fields using projection options', t => {
   return users.insert([
     { a: 1, b: 2 },
     { a: 1, b: 1 }
   ]).then(() => {
-    return users.find({ sort: true }, { fields: { a: 1 } })
+    return users.find({ sort: true }, { projection: { a: 1 } })
   }).then((docs) => {
     t.is(docs[0].a, 1)
     t.is(docs[0].b, undefined)


### PR DESCRIPTION
Updated collection.find() to advice users to no longer use `fields` as it has been deprecated in favor of `projection`.   This field was added to mongo driver 2.2. 

resolves: https://github.com/Automattic/monk/issues/303 