### PR TITLE
Added the ability to reuse a MongoClient instance

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -134,7 +134,14 @@ inherits(Manager, EventEmitter)
  * @private
  */
 Manager.prototype.open = function (uri, opts, fn) {
-  MongoClient.connect(uri, opts, function (err, client) {
+  // uri is a MongoClient instance. Don't emit 'open' immediately
+  if (typeof uri !== 'string') {
+    process.nextTick(cb.bind(this, null, uri))
+  } else {
+    MongoClient.connect(uri, opts, cb.bind(this))
+  }
+
+  function cb (err, client) {
     if (err) {
       this._state = STATE.CLOSED
       this.emit('error-opening', err)
@@ -160,7 +167,7 @@ Manager.prototype.open = function (uri, opts, fn) {
     if (fn) {
       fn(err, this)
     }
-  }.bind(this))
+  }
 }
 
 /**

--- a/test/collection.js
+++ b/test/collection.js
@@ -4,7 +4,8 @@ const monk = require('../lib/monk')
 
 const db = monk('127.0.0.1/monk')
 db.addMiddleware(require('monk-middleware-debug'))
-const users = db.get('users-' + Date.now())
+const usersName = 'users-' + Date.now()
+const users = db.get(usersName)
 const indexCol = db.get('index-' + Date.now())
 
 test.after(() => {
@@ -723,4 +724,14 @@ test('stats', (t) => {
 
 test.cb('stats > callback', (t) => {
   users.stats(t.end)
+})
+
+test('findOne with a mongo client passed to the manager', (t) => {
+  return users.insert({ a: 'b', c: 'd', e: 'f' }).then((doc) => {
+    return monk(db._client).then((db2) => {
+      return db2.get(usersName).findOne(doc._id).then(doc => {
+        t.is(doc.a, 'b')
+      })
+    })
+  })
 })

--- a/test/monk.js
+++ b/test/monk.js
@@ -34,9 +34,28 @@ test.cb('to a regular server', (t) => {
   })
 })
 
+test('connect with an existing mongo client instance', (t) => {
+  t.plan(3)
+  return monk('127.0.0.1/monk-test', (err, db) => {
+    t.falsy(err)
+    return monk(db._client, (err, db) => {
+      t.falsy(err)
+      t.true(db instanceof monk)
+    })
+  })
+})
+
 test('connect with promise', (t) => {
   return monk('127.0.0.1/monk-test').then((db) => {
     t.true(db instanceof monk)
+  })
+})
+
+test('connect with an existing mongo client instance with a promise', (t) => {
+  return monk('127.0.0.1/monk-test').then((db) => {
+    return monk(db._client).then((db2) => {
+      t.true(db2 instanceof monk)
+    })
   })
 })
 


### PR DESCRIPTION
**Use case**

This is helpful when you want to use Monk within `migrate-mongo` migration files where you are supplied with a MongoClient instance in their methods.

**Example**

```js
monk('127.0.0.1/my-db', (err, db) => {
  monk(db._client, (err, db2) => {..})
})
```