### PR TITLE
Fixes bug in .d.ts where all queries are assumed to be rawCursor queries.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -198,7 +198,7 @@ declare module "monk" {
     // Raw
     find(
       query: FilterQuery<T>,
-      options?: FindOptions<T> & { rawCursor: true }
+      options: FindOptions<T> & { rawCursor: true }
     ): Promise<FindRawResult<T>>;
     find(
       query: FilterQuery<T>,


### PR DESCRIPTION
This patch changes index.d.ts to not assume all `find` operations return a RawCursor. This is a one character fix, but is crucial for utilising monk inside typescript.