### PR TITLE
Removes deprecation warning from collection.count, as it uses an undeprecated function internally.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -144,8 +144,7 @@ declare module "monk" {
     ): void;
 
     /**
-     * http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#count
-     * @deprecated Use countDocuments or estimatedDocumentCount
+     * http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#countDocuments
      */
     count(
       query?: FilterQuery<T>,


### PR DESCRIPTION
Hi, another small issue in the .d.ts files - collection.count is marked as deprecated but according to monk docs (and from what I can see) this uses countDocuments internally, which is *not* deprecated.
