### PR TITLE
Stop throwing parsing errors

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -10,7 +10,9 @@ var ObjectId = require('mongodb').ObjectID
 
 exports.id = function (str) {
   if (str == null) return ObjectId()
-  return typeof str === 'string' ? ObjectId.createFromHexString(str) : str
+  if (typeof str !== 'string') return str
+  try { return ObjectId.createFromHexString(str) }
+  catch (e) { return str }
 }
 
 /**


### PR DESCRIPTION
`{ _id: '5ce26c0cb1476f59f287223dd' }` would yield:

Error: Argument passed in must be a single String of 12 bytes or a string of 24 hex characters
    at Function.createFromHexString (/node_modules/bson/lib/bson/objectid.js:312:11)
    at Object.exports.id (/node_modules/monk/lib/helpers.js:13:45)
    at /node_modules/monk/lib/helpers.js:39:29
    at Array.forEach (<anonymous>